### PR TITLE
fix: node version warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
         with:
           fetch-depth: 0  # Fetch full history for all branches to detect changes

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ inputs:
     default: true
     type: boolean
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"


### PR DESCRIPTION

<img width="1279" alt="Capture d’écran 2024-10-26 à 17 04 16" src="https://github.com/user-attachments/assets/0ac6dc11-2152-4cd4-94b2-25f93865aa1e">
Fix node version warning.

Github actions are now forced to use node20. [doc](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)